### PR TITLE
Fix file manager macOS check

### DIFF
--- a/workspace/BENJAMIN/jarvis/skills/file_manager.py
+++ b/workspace/BENJAMIN/jarvis/skills/file_manager.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import subprocess
 import logging
+import platform
 from jarvis.config import Config
 
 logger = logging.getLogger(__name__)
@@ -41,7 +42,7 @@ def handle(intent: str, params: dict, context: dict) -> str:
             # Cross-platform open:
             if os.name == "nt":  # Windows
                 os.startfile(file_path)
-            elif os.uname().sysname == "Darwin":  # macOS
+            elif platform.system() == "Darwin":  # macOS
                 subprocess.run(["open", file_path])
             else:  # Linux and others
                 subprocess.run(["xdg-open", file_path])


### PR DESCRIPTION
## Summary
- switch to `platform.system()` for OS detection in file manager
- import `platform`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421e88e14883289ed5a94ca2ccd086