### PR TITLE
Remove unused Config import

### DIFF
--- a/workspace/BENJAMIN/jarvis/memory/vector_store.py
+++ b/workspace/BENJAMIN/jarvis/memory/vector_store.py
@@ -8,7 +8,6 @@ import faiss
 import numpy as np
 import os
 import logging
-from jarvis.config import Config
 from sentence_transformers import SentenceTransformer  # e.g. 'all-MiniLM-L6-v2'
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- clean up unused Config import in VectorStore

## Testing
- `tools/linters` *(fails: No such file or directory)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421e89e9f88328925010d37a008971