### PR TITLE
Add conversational skill

### DIFF
--- a/workspace/BENJAMIN/jarvis/main.py
+++ b/workspace/BENJAMIN/jarvis/main.py
@@ -58,7 +58,14 @@ class JarvisAssistant:
             can_handle(intent: str) -> bool
             handle(intent: str, params: dict, context: dict) -> str
         """
-        from jarvis.skills import file_manager, scheduler, coding_helper, smart_home, info_query
+        from jarvis.skills import (
+            file_manager,
+            scheduler,
+            coding_helper,
+            smart_home,
+            info_query,
+            conversation,
+        )
 
         # Example registry: list of skill modules
         return [
@@ -66,7 +73,8 @@ class JarvisAssistant:
             scheduler,
             coding_helper,
             smart_home,
-            info_query
+            info_query,
+            conversation,
         ]
 
     def _handle_input(self, raw_text: str, source: str = "voice"):
@@ -82,6 +90,7 @@ class JarvisAssistant:
         intent, entities = self.intent_recognizer.parse(raw_text)
         context = self.stm.get_context()  # Retrieves recent context
         intent, entities = self.dialogue_manager.resolve_follow_up(intent, entities, context)
+        entities["text"] = raw_text  # pass raw input to skills
         response = self._dispatch_intent(intent, entities, context)
         # Update STM with this turn
         self.stm.append(turn={"input": raw_text, "intent": intent, "entities": entities, "response": response})

--- a/workspace/BENJAMIN/jarvis/skills/conversation.py
+++ b/workspace/BENJAMIN/jarvis/skills/conversation.py
@@ -1,0 +1,33 @@
+import logging
+import openai
+from jarvis.config import Config
+
+logger = logging.getLogger(__name__)
+
+cfg = Config()
+openai.api_key = cfg.get("api_keys", "openai")
+
+
+def can_handle(intent: str) -> bool:
+    # Fallback skill for general conversation
+    return True
+
+
+def handle(intent: str, params: dict, context: dict) -> str:
+    """Generate a response using OpenAI ChatGPT."""
+    prompt = params.get("text", "")
+    if not prompt:
+        return "I'm not sure what you want me to talk about."
+    try:
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        msg = resp.choices[0].message["content"].strip()
+        return msg
+    except Exception as e:
+        logger.exception("ChatGPT request failed: %s", e)
+        return "Sorry, I couldn't think of a reply."

--- a/workspace/BENJAMIN/pyproject.toml
+++ b/workspace/BENJAMIN/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pywemo>=0.6.0",
     "pytest>=7.2.0",
     "python-dotenv>=0.21.0",
+    "openai>=0.28.0",
 ]
 
 [tool.pytest.ini_options]

--- a/workspace/BENJAMIN/requirements.txt
+++ b/workspace/BENJAMIN/requirements.txt
@@ -19,3 +19,4 @@ phue>=1.2.0                # Philips Hue integration (smart home)
 pywemo>=0.6.0              # Belkin WeMo integration
 pytest>=7.2.0              # for running unit tests
 python-dotenv>=0.21.0      # optionally load environment variables
+openai>=0.28.0             # ChatGPT integration for conversation

--- a/workspace/BENJAMIN/tests/test_conversation.py
+++ b/workspace/BENJAMIN/tests/test_conversation.py
@@ -1,0 +1,14 @@
+import types
+from jarvis.skills import conversation
+
+
+def test_conversation_handles_any_intent(monkeypatch):
+    # Mock OpenAI response
+    def fake_create(**kwargs):
+        class Resp:
+            choices = [types.SimpleNamespace(message={"content": "Hi there"})]
+        return Resp()
+
+    monkeypatch.setattr(conversation.openai.ChatCompletion, "create", fake_create)
+    response = conversation.handle("unknown", {"text": "Hello"}, {})
+    assert "Hi there" in response


### PR DESCRIPTION
## Summary
- add new OpenAI-based `conversation` skill for fallback chat responses
- load the conversation skill and pass raw text to skills
- add OpenAI dependency to project config
- test conversation handling with a mocked ChatGPT response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421d19085c8328ace5ab285d0df8c1