### PR TITLE
Add chat window startup

### DIFF
--- a/workspace/BENJAMIN/README.md
+++ b/workspace/BENJAMIN/README.md
@@ -12,8 +12,9 @@ This repository contains a modular, “Jarvis-style” personal assistant that s
 **Getting Started:**  
 1. Create a virtual environment (e.g., `python3 -m venv venv && source venv/bin/activate`).  
 2. Install dependencies: `pip install -r requirements.txt`.  
-3. Populate `config/config.yaml` with your API keys, device names, etc.  
-4. Run Jarvis: `bash scripts/run_jarvis.sh` or `python -m jarvis.main`.  
+3. Populate `config/config.yaml` with your API keys, device names, etc.
+4. To try a simple chat window run: `python -m jarvis` or `python -m jarvis.chat_app`.
+   Voice/terminal mode is still available via `bash scripts/run_jarvis.sh`.
 
 **Modules Breakdown:**  
 - `interfaces/`         : Voice & terminal I/O, wake-word listening.  

--- a/workspace/BENJAMIN/jarvis/__main__.py
+++ b/workspace/BENJAMIN/jarvis/__main__.py
@@ -1,0 +1,4 @@
+from .chat_app import main
+
+if __name__ == "__main__":
+    main()

--- a/workspace/BENJAMIN/jarvis/chat_app.py
+++ b/workspace/BENJAMIN/jarvis/chat_app.py
@@ -1,0 +1,12 @@
+from jarvis.main import JarvisAssistant
+from jarvis.interfaces.chat_interface import ChatInterface
+
+
+def main():
+    assistant = JarvisAssistant(enable_voice=False, enable_terminal=False)
+    chat = ChatInterface(assistant.process_input)
+    chat.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/workspace/BENJAMIN/jarvis/interfaces/chat_interface.py
+++ b/workspace/BENJAMIN/jarvis/interfaces/chat_interface.py
@@ -1,0 +1,47 @@
+import tkinter as tk
+from tkinter.scrolledtext import ScrolledText
+
+
+class ChatInterface:
+    """Simple Tkinter-based chat window."""
+
+    def __init__(self, handle_func):
+        """
+        Parameters
+        ----------
+        handle_func: callable
+            Function that takes a string input and returns a response string.
+        """
+        self.handle_func = handle_func
+        self.window = tk.Tk()
+        self.window.title("Jarvis Chat")
+
+        self.chat_log = ScrolledText(self.window, state="disabled", width=80, height=20)
+        self.chat_log.pack(padx=10, pady=10, fill="both", expand=True)
+
+        self.entry_var = tk.StringVar()
+        self.entry = tk.Entry(self.window, textvariable=self.entry_var)
+        self.entry.pack(fill="x", padx=10, pady=(0, 10))
+        self.entry.bind("<Return>", self._on_enter)
+
+    def start(self):
+        self.entry.focus()
+        self.window.mainloop()
+
+    def display(self, text: str):
+        self._append(text)
+
+    def _on_enter(self, event=None):
+        user_text = self.entry_var.get().strip()
+        if user_text:
+            self._append(f"You: {user_text}")
+            response = self.handle_func(user_text)
+            if response:
+                self._append(f"Jarvis: {response}")
+        self.entry_var.set("")
+
+    def _append(self, text: str):
+        self.chat_log.configure(state="normal")
+        self.chat_log.insert(tk.END, text + "\n")
+        self.chat_log.configure(state="disabled")
+        self.chat_log.see(tk.END)


### PR DESCRIPTION
## Summary
- create ChatInterface GUI using Tkinter
- allow JarvisAssistant to run without voice/terminal interfaces
- expose a `chat_app` module and default `jarvis` entrypoint
- document new chat window in README

## Testing
- `pip install PyYAML openai`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684226eb3b6083288f2d92b11b0999a6