### PR TITLE
Fix configuration memory paths

### DIFF
--- a/jarvis/main.py
+++ b/jarvis/main.py
@@ -27,8 +27,12 @@ class JarvisAssistant:
         logger.info("Loaded configuration.")
 
         # Initialize persistent memory
-        self.ltm = LongTermMemory(self.cfg.get("memory", "long_term_db_path"))
-        self.stm = ShortTermMemory(capacity=self.cfg.get("memory", "short_term_capacity"))
+        self.ltm = LongTermMemory(
+            self.cfg.get("assistant", "memory", "long_term_db_path")
+        )
+        self.stm = ShortTermMemory(
+            capacity=self.cfg.get("assistant", "memory", "short_term_capacity")
+        )
         logger.info("Memory modules initialized.")
 
         # Initialize NLU components

--- a/jarvis/skills/scheduler.py
+++ b/jarvis/skills/scheduler.py
@@ -26,7 +26,7 @@ def handle(intent: str, params: dict, context: dict) -> str:
     APScheduler jobs fire at the specified datetime to send notifications.
     """
     cfg = Config()
-    db_path = cfg.get("memory", "long_term_db_path")
+    db_path = cfg.get("assistant", "memory", "long_term_db_path")
     conn = sqlite3.connect(db_path)
     c = conn.cursor()
     c.execute(


### PR DESCRIPTION
## Summary
- initialize memory using the assistant.memory config section
- reference the correct config path in the scheduler skill

## Testing
- `pip install -q -r requirements.txt` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68426d8b46a4832897707bfad7844f5c