### PR TITLE
Fix optional dependency issues

### DIFF
--- a/jarvis/chat_app.py
+++ b/jarvis/chat_app.py
@@ -1,10 +1,17 @@
 from jarvis.main import JarvisAssistant
 from jarvis.interfaces.chat_interface import ChatInterface
+from jarvis.interfaces.terminal_interface import TerminalInterface
 
 
 def main():
     assistant = JarvisAssistant(enable_voice=False, enable_terminal=False)
-    chat = ChatInterface(assistant.process_input)
+    try:
+        chat = ChatInterface(assistant.process_input)
+    except RuntimeError:
+        # GUI not available; fallback to simple terminal interface
+        term = TerminalInterface(callback=assistant.process_input)
+        term.listen_loop()
+        return
     chat.start()
 
 

--- a/jarvis/interfaces/chat_interface.py
+++ b/jarvis/interfaces/chat_interface.py
@@ -1,5 +1,6 @@
 import tkinter as tk
 from tkinter.scrolledtext import ScrolledText
+from tkinter import TclError
 
 
 class ChatInterface:
@@ -13,7 +14,10 @@ class ChatInterface:
             Function that takes a string input and returns a response string.
         """
         self.handle_func = handle_func
-        self.window = tk.Tk()
+        try:
+            self.window = tk.Tk()
+        except TclError as e:  # pragma: no cover - GUI may be unavailable
+            raise RuntimeError("Tkinter GUI unavailable") from e
         self.window.title("Jarvis Chat")
 
         self.chat_log = ScrolledText(self.window, state="disabled", width=80, height=20)

--- a/jarvis/learning/reinforcement.py
+++ b/jarvis/learning/reinforcement.py
@@ -6,7 +6,14 @@
 
 import logging
 import numpy as np
-from stable_baselines3 import PPO
+
+try:
+    from stable_baselines3 import PPO
+except Exception as e:  # pragma: no cover - optional dependency
+    PPO = None
+    logging.getLogger(__name__).warning(
+        "stable-baselines3 not available: %s", e
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +25,10 @@ class ReinforcementAgent:
     """
 
     def __init__(self, model_path: str):
+        if PPO is None:
+            logger.warning("Reinforcement learning disabled: stable-baselines3 not installed")
+            self.model = None
+            return
         try:
             self.model = PPO.load(model_path)
             logger.info("ReinforcementAgent loaded model from %s.", model_path)


### PR DESCRIPTION
## Summary
- make `stable_baselines3` optional for ReinforcementAgent
- disable scheduler skill if APScheduler missing
- handle missing Tkinter GUI when starting chat app
- fallback to terminal interface if no GUI

## Testing
- `pytest -q`
- `python -m jarvis.chat_app <<'EOF'
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68434300d6588328b5d4e16ec5977cb5