### PR TITLE
Fix OpenAI API usage after v1 upgrade

### DIFF
--- a/jarvis/skills/conversation.py
+++ b/jarvis/skills/conversation.py
@@ -19,14 +19,14 @@ def handle(intent: str, params: dict, context: dict) -> str:
     if not prompt:
         return "I'm not sure what you want me to talk about."
     try:
-        resp = openai.ChatCompletion.create(
+        resp = openai.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[
                 {"role": "system", "content": "You are a helpful assistant."},
                 {"role": "user", "content": prompt},
             ],
         )
-        msg = resp.choices[0].message["content"].strip()
+        msg = resp.choices[0].message.content.strip()
         return msg
     except Exception as e:
         logger.exception("ChatGPT request failed: %s", e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pywemo>=0.6.0",
     "pytest>=7.2.0",
     "python-dotenv>=0.21.0",
-    "openai>=0.28.0",
+    "openai>=1.0.0",
 ]
 
 [tool.pytest.ini_options]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ phue==1.1                  # Philips Hue integration (smart home)
 pywemo>=0.6.0              # Belkin WeMo integration
 pytest>=7.2.0              # for running unit tests
 python-dotenv>=0.21.0      # optionally load environment variables
-openai>=0.28.0             # ChatGPT integration for conversation
+openai>=1.0.0             # ChatGPT integration for conversation

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -6,9 +6,10 @@ def test_conversation_handles_any_intent(monkeypatch):
     # Mock OpenAI response
     def fake_create(**kwargs):
         class Resp:
-            choices = [types.SimpleNamespace(message={"content": "Hi there"})]
+            choices = [types.SimpleNamespace(message=types.SimpleNamespace(content="Hi there"))]
+
         return Resp()
 
-    monkeypatch.setattr(conversation.openai.ChatCompletion, "create", fake_create)
+    monkeypatch.setattr(conversation.openai.chat.completions, "create", fake_create)
     response = conversation.handle("unknown", {"text": "Hello"}, {})
     assert "Hi there" in response


### PR DESCRIPTION
## Summary
- update conversation skill to use the new OpenAI `chat.completions` API
- adjust tests to mock the new interface
- require `openai>=1.0` in dependency lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843bcc5cd888328a1f9215d6ce8cac6