### PR TITLE
Add short-term conversation history support

### DIFF
--- a/jarvis/main.py
+++ b/jarvis/main.py
@@ -118,9 +118,13 @@ class JarvisAssistant:
         then call its handle() method.
         If no skill can handle it, return a fallback message.
         """
+        # Pass recent conversation turns so skills can leverage short term memory
+        ctx = dict(context) if context else {}
+        ctx["recent_turns"] = self.stm.get_recent_turns()
+
         for skill in self.skill_registry:
             if skill.can_handle(intent):
-                return skill.handle(intent, params, context)
+                return skill.handle(intent, params, ctx)
         logger.warning("No skill found to handle intent '%s'", intent)
         return "Sorry, I didn’t understand that. Can you rephrase?"
 

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -13,3 +13,40 @@ def test_conversation_handles_any_intent(monkeypatch):
     monkeypatch.setattr(conversation.openai.chat.completions, "create", fake_create)
     response = conversation.handle("unknown", {"text": "Hello"}, {})
     assert "Hi there" in response
+
+
+def test_conversation_includes_history(monkeypatch):
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured['messages'] = kwargs.get('messages')
+
+        class Resp:
+            choices = [
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(content="Sure")
+                )
+            ]
+
+        return Resp()
+
+    monkeypatch.setattr(conversation.openai.chat.completions, "create", fake_create)
+
+    history = [
+        {"input": "hi", "response": "hello"},
+        {"input": "how are you?", "response": "fine"},
+    ]
+
+    conversation.handle("unknown", {"text": "tell me a joke"}, {"recent_turns": history})
+
+    msgs = captured['messages']
+    expected = [
+        {"role": "system", "content": f"You are {conversation.ASSISTANT_NAME}, a helpful assistant."},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "how are you?"},
+        {"role": "assistant", "content": "fine"},
+        {"role": "user", "content": "tell me a joke"},
+    ]
+
+    assert msgs == expected


### PR DESCRIPTION
## Summary
- include recent short-term memory turns when dispatching intents
- build ChatGPT message list from recent turns in conversation skill
- test that conversation history is passed to OpenAI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d0e3a2d88328bfee4681b2f17b44