### PR TITLE
Update test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,16 @@ This repository contains a modular, “Jarvis-style” personal assistant that s
 - `utils/`              : Logging, common helpers.  
 
 For more details, see `docs/` (design documents, architecture diagrams).
+
+## Running Tests
+Before executing the test suite, make sure all dependencies are installed:
+
+```
+pip install -r requirements.txt
+```
+
+Then run the tests with:
+
+```
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,12 @@ dependencies = [
     "openai>=1.0.0",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "openai",
+    "PyYAML",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-vv"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+openai
+PyYAML


### PR DESCRIPTION
## Summary
- document how to run tests in README
- provide optional dev dependencies via pyproject extra
- add `tests/requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: ModuleNotFoundError: openai, yaml)*
- `pytest -q` *(fails: ModuleNotFoundError: openai, yaml)*

------
https://chatgpt.com/codex/tasks/task_e_6843d0e39e188328b33d471e467e9a8d