### PR TITLE
Add Rasa NLU option

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,7 +7,7 @@ assistant:
   wake_word: "hey jarvis"             # Wake-word phrase
   stt_engine: "vosk"                  # Options: 'vosk', 'whisper', etc.
   tts_engine: "pyttsx3"               # Options: 'pyttsx3', 'coqui', 'gtts'
-  nlu_engine: "spacy"                 # Options: 'spacy'
+  nlu_engine: "spacy"                 # Options: 'spacy', 'rasa'
   memory:
     short_term_capacity: 50           # Number of recent turns to keep in RAM
     long_term_db_path: "data/memory.db"

--- a/jarvis/main.py
+++ b/jarvis/main.py
@@ -12,6 +12,7 @@ from jarvis.config import Config
 from jarvis.interfaces.voice_interface import VoiceInterface
 from jarvis.interfaces.terminal_interface import TerminalInterface
 from jarvis.nlu.intent_recognizer import IntentRecognizer
+# RasaInterpreter is imported lazily to avoid heavy dependency unless required
 from jarvis.nlu.dialogue_manager import DialogueManager
 from jarvis.memory.short_term import ShortTermMemory
 from jarvis.memory.long_term import LongTermMemory
@@ -35,10 +36,16 @@ class JarvisAssistant:
         )
         logger.info("Memory modules initialized.")
 
-        # Initialize NLU components
-        self.intent_recognizer = IntentRecognizer()
+        # Initialize NLU components based on configuration
+        engine = self.cfg.get("assistant", "nlu_engine", default="spacy")
+        if engine == "rasa":
+            from jarvis.nlu.rasa_interpreter import RasaInterpreter
+
+            self.intent_recognizer = RasaInterpreter()
+        else:
+            self.intent_recognizer = IntentRecognizer()
         self.dialogue_manager = DialogueManager()
-        logger.info("NLU modules initialized.")
+        logger.info("NLU modules initialized using %s engine.", engine)
 
         # Initialize skill registry (mapping intents to handler functions)
         self.skill_registry = self._load_skills()

--- a/jarvis/nlu/rasa_interpreter.py
+++ b/jarvis/nlu/rasa_interpreter.py
@@ -1,0 +1,35 @@
+"""Rasa NLU interpreter wrapper.
+
+This module provides a simple wrapper around ``rasa.nlu.model.Interpreter``
+to make it compatible with the ``IntentRecognizer`` interface used by
+``JarvisAssistant``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Tuple
+
+from rasa.nlu.model import Interpreter
+
+logger = logging.getLogger(__name__)
+
+
+class RasaInterpreter:
+    """Load a Rasa NLU model and expose a ``parse`` method."""
+
+    def __init__(self, model_path: str = "models/rasa_nlu") -> None:
+        self.model_path = model_path
+        try:
+            self.interpreter = Interpreter.load(model_path)
+        except Exception as exc:  # pragma: no cover - handled by Rasa
+            logger.error("Failed to load Rasa model from %s: %s", model_path, exc)
+            raise
+
+    def parse(self, text: str) -> Tuple[str, Dict[str, str]]:
+        """Return ``(intent, entities)`` for the supplied ``text``."""
+        result = self.interpreter.parse(text)
+        intent = result.get("intent", {}).get("name", "unknown")
+        entities = {ent["entity"]: ent["value"] for ent in result.get("entities", [])}
+        logger.debug("Parsed intent %s with entities %s", intent, entities)
+        return intent, entities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pytest>=7.2.0",
     "python-dotenv>=0.21.0",
     "openai>=1.0.0",
+    "rasa>=3.1",
 ]
 
 [project.optional-dependencies]

--- a/rasa/config.yml
+++ b/rasa/config.yml
@@ -1,0 +1,9 @@
+version: "3.1"
+language: en
+pipeline:
+  - name: WhitespaceTokenizer
+  - name: RegexFeaturizer
+  - name: LexicalSyntacticFeaturizer
+  - name: CountVectorsFeaturizer
+  - name: DIETClassifier
+  - name: EntitySynonymMapper

--- a/rasa/data/nlu.yml
+++ b/rasa/data/nlu.yml
@@ -1,0 +1,18 @@
+version: "3.1"
+nlu:
+  - intent: greet
+    examples: |
+      - hi
+      - hello
+      - hey
+      - good morning
+  - intent: goodbye
+    examples: |
+      - bye
+      - goodbye
+      - see you later
+  - intent: weather_query
+    examples: |
+      - what's the weather in [Berlin](location)?
+      - weather for [New York](location)
+      - tell me the weather in [London](location)

--- a/rasa/domain.yml
+++ b/rasa/domain.yml
@@ -1,0 +1,10 @@
+version: "3.1"
+intents:
+  - greet
+  - goodbye
+  - weather_query
+responses:
+  utter_greet:
+    - text: "Hello!"
+  utter_goodbye:
+    - text: "Goodbye!"

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ pywemo>=0.6.0              # Belkin WeMo integration
 pytest>=7.2.0              # for running unit tests
 python-dotenv>=0.21.0      # optionally load environment variables
 openai>=1.0.0             # ChatGPT integration for conversation
+rasa>=3.1                 # optional: use Rasa NLU engine

--- a/scripts/train_rasa_nlu.py
+++ b/scripts/train_rasa_nlu.py
@@ -1,0 +1,28 @@
+"""Train Rasa NLU model and copy it to models/rasa_nlu."""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+
+
+def main() -> None:
+    base_dir = pathlib.Path(__file__).resolve().parents[1]
+    rasa_dir = base_dir / "rasa"
+    models_dir = base_dir / "models" / "rasa_nlu"
+    models_dir.mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(["rasa", "train", "nlu"], cwd=rasa_dir, check=True)
+
+    trained_models = sorted((rasa_dir / "models").glob("*.tar.gz"), key=lambda p: p.stat().st_mtime, reverse=True)
+    if not trained_models:
+        raise RuntimeError("No trained Rasa model found")
+    latest = trained_models[0]
+    dest = models_dir / latest.name
+    shutil.copy(latest, dest)
+    print(f"Model copied to {dest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rasa_nlu.py
+++ b/tests/test_rasa_nlu.py
@@ -1,0 +1,19 @@
+import pathlib
+import importlib
+import pytest
+
+try:
+    importlib.import_module("rasa.nlu.model")
+except Exception:
+    pytest.skip("rasa not available", allow_module_level=True)
+
+from jarvis.nlu.rasa_interpreter import RasaInterpreter
+
+MODEL_DIR = pathlib.Path("models/rasa_nlu")
+
+@pytest.mark.skipif(not MODEL_DIR.exists(), reason="Rasa model not available")
+def test_rasa_interpreter_greet():
+    interpreter = RasaInterpreter(str(MODEL_DIR))
+    intent, entities = interpreter.parse("hello")
+    assert intent == "greet"
+    assert isinstance(entities, dict)


### PR DESCRIPTION
## Summary
- support Rasa as an alternative NLU backend
- add minimal Rasa training data and config
- provide script for training Rasa NLU models
- configure engine selection through `config.yaml`
- include a unit test for the Rasa interpreter
- declare `rasa` dependency

## Testing
- `pip install -q -r tests/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d3dc95708328b6f54aa97f585374