### PR TITLE
Add vector store caching and integration

### DIFF
--- a/jarvis/memory/cache.py
+++ b/jarvis/memory/cache.py
@@ -1,0 +1,30 @@
+# jarvis/memory/cache.py
+# -----------------------------------
+# Simple in-memory LRU cache used by memory components.
+# -----------------------------------
+
+from collections import OrderedDict
+from typing import Any
+
+class LRUCache:
+    """Lightweight LRU cache storing the most recent items."""
+
+    def __init__(self, maxsize: int = 128) -> None:
+        self.maxsize = maxsize
+        self._cache: OrderedDict[Any, Any] = OrderedDict()
+
+    def get(self, key: Any) -> Any:
+        if key in self._cache:
+            self._cache.move_to_end(key)
+            return self._cache[key]
+        return None
+
+    def set(self, key: Any, value: Any) -> None:
+        if key in self._cache:
+            self._cache.move_to_end(key)
+        self._cache[key] = value
+        if len(self._cache) > self.maxsize:
+            self._cache.popitem(last=False)
+
+    def clear(self) -> None:
+        self._cache.clear()

--- a/jarvis/skills/conversation.py
+++ b/jarvis/skills/conversation.py
@@ -1,5 +1,15 @@
 import logging
-import openai
+import types
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - provide dummy for tests
+    openai = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=lambda **_: types.SimpleNamespace(choices=[]))
+        )
+    )
+
 from jarvis.config import Config
 
 logger = logging.getLogger(__name__)

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,40 @@
+import numpy as np
+from jarvis.memory import vector_store as vs_module
+from jarvis.memory.vector_store import VectorStore
+
+
+class DummyModel:
+    def __init__(self):
+        self.calls = 0
+
+    def get_sentence_embedding_dimension(self):
+        return 3
+
+    def encode(self, texts):
+        self.calls += 1
+        return np.array([[len(t)] * 3 for t in texts], dtype=np.float32)
+
+
+def setup_vector_store(tmp_path, monkeypatch):
+    monkeypatch.setattr(vs_module, "SentenceTransformer", lambda name="": DummyModel())
+    store = VectorStore(str(tmp_path / "index"))
+    # type: ignore[attr-defined]
+    model = store.model  # type: ignore
+    return store, model
+
+
+def test_store_and_retrieve(tmp_path, monkeypatch):
+    store, _ = setup_vector_store(tmp_path, monkeypatch)
+    store.store("hello")
+    store.store("world")
+    res = store.retrieve("hello", top_k=1)
+    assert res == ["hello"]
+
+
+def test_retrieve_uses_cache(tmp_path, monkeypatch):
+    store, model = setup_vector_store(tmp_path, monkeypatch)
+    store.store("hello")
+    first = store.retrieve("hello")
+    second = store.retrieve("hello")
+    assert first == second
+    assert model.calls == 2  # encode called once for store and once for retrieve


### PR DESCRIPTION
## Summary
- implement `LRUCache` helper
- support optional dependencies in `VectorStore` and add caching
- initialize `VectorStore` inside `JarvisAssistant`
- store conversation text and return related turns via context
- stub OpenAI import so tests run without installing package
- add unit tests for the vector store

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d3e5ad648328b49f63a9b163bc4b