### PR TITLE
Introduce CoreController for conversation handling

### DIFF
--- a/jarvis/core_controller.py
+++ b/jarvis/core_controller.py
@@ -1,0 +1,76 @@
+import logging
+from typing import List
+
+from jarvis.nlu.intent_recognizer import IntentRecognizer
+from jarvis.nlu.dialogue_manager import DialogueManager
+from jarvis.memory.short_term import ShortTermMemory
+from jarvis.memory.long_term import LongTermMemory
+from jarvis.memory.vector_store import VectorStore
+from jarvis.utils.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+class CoreController:
+    """Central coordinator for processing user inputs."""
+
+    def __init__(
+        self,
+        intent_recognizer: IntentRecognizer,
+        dialogue_manager: DialogueManager,
+        stm: ShortTermMemory,
+        ltm: LongTermMemory,
+        vector_store: VectorStore,
+        skill_registry: List,
+    ) -> None:
+        self.intent_recognizer = intent_recognizer
+        self.dialogue_manager = dialogue_manager
+        self.stm = stm
+        self.ltm = ltm
+        self.vector_store = vector_store
+        self.skill_registry = skill_registry
+
+    def handle_input(self, text: str) -> str:
+        """Process raw text and return a response string."""
+        intent, entities = self.intent_recognizer.parse(text)
+
+        context = self.stm.get_context()
+        # Include vector store context if available
+        if self.vector_store:
+            try:
+                indices, _ = self.vector_store.query_similar(text)
+                context["similar_turns"] = [int(i) for i in indices if i != -1]
+            except Exception as e:  # pragma: no cover - optional dependency
+                logger.warning("Vector store query failed: %s", e)
+
+        intent, entities = self.dialogue_manager.resolve_follow_up(intent, entities, context)
+        entities["text"] = text
+
+        response = self._dispatch_intent(intent, entities, context)
+
+        self.stm.append(
+            {"input": text, "intent": intent, "entities": entities, "response": response}
+        )
+        if self.ltm:
+            try:
+                self.ltm.log_interaction(text, intent, response)
+            except Exception as e:  # pragma: no cover - optional dependency
+                logger.warning("Failed to log interaction: %s", e)
+        if self.vector_store:
+            try:
+                self.vector_store.add_turn(text)
+            except Exception as e:  # pragma: no cover - optional dependency
+                logger.warning("Vector store update failed: %s", e)
+
+        return response
+
+    def _dispatch_intent(self, intent: str, params: dict, context: dict) -> str:
+        """Dispatch the intent to the first skill that can handle it."""
+        ctx = dict(context) if context else {}
+        ctx["recent_turns"] = self.stm.get_recent_turns()
+
+        for skill in self.skill_registry:
+            if skill.can_handle(intent):
+                return skill.handle(intent, params, ctx)
+        logger.warning("No skill found to handle intent '%s'", intent)
+        return "Sorry, I didn’t understand that. Can you rephrase?"

--- a/jarvis/main.py
+++ b/jarvis/main.py
@@ -15,6 +15,8 @@ from jarvis.nlu.intent_recognizer import IntentRecognizer
 from jarvis.nlu.dialogue_manager import DialogueManager
 from jarvis.memory.short_term import ShortTermMemory
 from jarvis.memory.long_term import LongTermMemory
+from jarvis.memory.vector_store import VectorStore
+from jarvis.core_controller import CoreController
 from jarvis.learning.reinforcement import ReinforcementAgent
 from jarvis.utils.logger import get_logger
 
@@ -33,6 +35,9 @@ class JarvisAssistant:
         self.stm = ShortTermMemory(
             capacity=self.cfg.get("assistant", "memory", "short_term_capacity")
         )
+        self.vector_store = VectorStore(
+            self.cfg.get("assistant", "memory", "vector_store_path")
+        )
         logger.info("Memory modules initialized.")
 
         # Initialize NLU components
@@ -44,6 +49,15 @@ class JarvisAssistant:
         self.skill_registry = self._load_skills()
         logger.info("Skill registry created with %d skills.", len(self.skill_registry))
 
+        self.controller = CoreController(
+            self.intent_recognizer,
+            self.dialogue_manager,
+            self.stm,
+            self.ltm,
+            self.vector_store,
+            self.skill_registry,
+        )
+        
         # Initialize learning agent (RL) for proactive suggestions
         self.rl_agent = ReinforcementAgent(model_path="models/rl_policy_final.zip")
         logger.info("Reinforcement learning agent loaded.")
@@ -88,12 +102,7 @@ class JarvisAssistant:
     def process_input(self, raw_text: str, source: str = "chat") -> str:
         """Process input text and return a response string."""
         logger.debug("Input received [%s]: %s", source, raw_text)
-        intent, entities = self.intent_recognizer.parse(raw_text)
-        context = self.stm.get_context()
-        intent, entities = self.dialogue_manager.resolve_follow_up(intent, entities, context)
-        entities["text"] = raw_text
-        response = self._dispatch_intent(intent, entities, context)
-        self.stm.append(turn={"input": raw_text, "intent": intent, "entities": entities, "response": response})
+        response = self.controller.handle_input(raw_text)
         self.rl_agent.observe(turn=self.stm.get_recent_turns(), memory=self.ltm)
         return response
 
@@ -112,21 +121,6 @@ class JarvisAssistant:
         if self.terminal_interface:
             self.terminal_interface.print(response)
 
-    def _dispatch_intent(self, intent: str, params: dict, context: dict) -> str:
-        """
-        Find the first skill module whose can_handle(intent) returns True,
-        then call its handle() method.
-        If no skill can handle it, return a fallback message.
-        """
-        # Pass recent conversation turns so skills can leverage short term memory
-        ctx = dict(context) if context else {}
-        ctx["recent_turns"] = self.stm.get_recent_turns()
-
-        for skill in self.skill_registry:
-            if skill.can_handle(intent):
-                return skill.handle(intent, params, ctx)
-        logger.warning("No skill found to handle intent '%s'", intent)
-        return "Sorry, I didn’t understand that. Can you rephrase?"
 
     def start(self):
         """Start both interfaces and set running=True."""


### PR DESCRIPTION
## Summary
- add `CoreController` that coordinates NLU, memory and skill dispatch
- refactor `JarvisAssistant` to use the new controller
- wire vector store usage and remove old dispatch logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d3e6f8208328a1fce143007e7481