### PR TITLE
Enable Rasa NLU engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This repository contains a modular, “Jarvis-style” personal assistant that s
 4. To try a simple chat window run: `python -m jarvis` or `python -m jarvis.chat_app`.
    Voice/terminal mode is still available via `bash scripts/run_jarvis.sh`.
 5. Train the spaCy based NLU model with `python scripts/train_spacy_nlu.py` (optional).
+6. To use the Rasa NLU engine instead, first train the Rasa model by running
+   `python scripts/train_rasa_nlu.py`. This will place the trained model under
+   `models/rasa_nlu/`. Then edit `config/config.yaml` and set
+   `assistant.nlu_engine: "rasa"`.
 
 **Modules Breakdown:**  
 - `interfaces/`         : Voice & terminal I/O, wake-word listening.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,7 +7,7 @@ assistant:
   wake_word: "hey jarvis"             # Wake-word phrase
   stt_engine: "vosk"                  # Options: 'vosk', 'whisper', etc.
   tts_engine: "pyttsx3"               # Options: 'pyttsx3', 'coqui', 'gtts'
-  nlu_engine: "spacy"                 # Options: 'spacy', 'rasa'
+  nlu_engine: "rasa"                  # Options: 'spacy', 'rasa'
   memory:
     short_term_capacity: 50           # Number of recent turns to keep in RAM
     long_term_db_path: "data/memory.db"

--- a/config/loader.py
+++ b/config/loader.py
@@ -18,7 +18,7 @@ class MemorySettings(BaseModel):
 class AssistantSettings(BaseModel):
     name: str = "Jarvis"
     language: str = "en"
-    wake_word: str = Field(..., alias="wake_word")
+    wake_word: str = Field("hey jarvis", alias="wake_word")
     stt_engine: str = "vosk"
     tts_engine: str = "pyttsx3"
     nlu_engine: str = "spacy"

--- a/jarvis/main.py
+++ b/jarvis/main.py
@@ -45,7 +45,13 @@ class JarvisAssistant:
         # Initialize NLU components based on configuration
         engine = self.cfg.get("assistant", "nlu_engine", default="spacy")
         if engine == "rasa":
-            self.intent_recognizer = RasaNLUAdapter()
+            adapter = RasaNLUAdapter()
+            if getattr(adapter, "interpreter", None) is None:
+                logger.warning("Rasa model unavailable, falling back to spaCy")
+                self.intent_recognizer = IntentRecognizer()
+                engine = "spacy"
+            else:
+                self.intent_recognizer = adapter
         else:
             self.intent_recognizer = IntentRecognizer()
         self.dialogue_manager = DialogueManager()


### PR DESCRIPTION
## Summary
- switch default NLU engine to Rasa
- make wake word optional in config loader
- fall back to spaCy if Rasa model is missing
- document how to train the Rasa model

## Testing
- `pytest -q`
- `python scripts/train_rasa_nlu.py` *(fails: FileNotFoundError: 'rasa')*

------
https://chatgpt.com/codex/tasks/task_e_6843ecea020c8328843047cbf5e67e58